### PR TITLE
fix: added activationEvents into package.json to resolve windows issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "Other"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onCommand:extension.openMyExtension",
+    "onCommand:extension.useMyExtension"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
Now works on windows
That was added based on the following similar issue https://stackoverflow.com/questions/49534068/command-not-found-in-vscode-extension

Related to #1 

![image](https://github.com/user-attachments/assets/4061cd77-26e6-4352-a954-b4982eda5753)
